### PR TITLE
Fixing the settings data setup

### DIFF
--- a/migrations/202008290730.do.nys-fix-settings.sql
+++ b/migrations/202008290730.do.nys-fix-settings.sql
@@ -1,0 +1,3 @@
+UPDATE settings set is_language = true;
+DELETE FROM settings WHERE settings_key = 'exposureConfig';
+INSERT INTO settings(settings_key, settings_value, is_language) VALUES('exposureConfig', '{\"minimumRiskScore\":1,\"attenuationLevelValues\":[2,3,4,5,6,7,8,8],\"attenuationWeight\":1,\"daysSinceLastExposureLevelValues\":[1,1,1,1,1,1,1,1],\"daysSinceLastExposureWeight\":1,\"durationLevelValues\":[1,1,1,1,1,1,1,1],\"durationWeight\":1,\"transmissionRiskLevelValues\":[1,1,1,1,1,1,1,1],\"transmissionRiskWeight\":1, \"durationAtAttenuationThresholds\": [56,62],\"thresholdWeightings\":[1,1,0],\"timeThreshold\":10}', false);


### PR DESCRIPTION
The settings are split in two files based on the flag is_language. When set to true it means that these settings are to be consumed by the app. When set to false it means the settings are to be consumed by the react native exposure notification service component.
This PR corrects the current settings data.

Also sets the exposure alert trigger time to 10 minutes which matches the text in the app.