### PR TITLE
Removing the metrics write from the initial register path

### DIFF
--- a/lib/routes/register/index.js
+++ b/lib/routes/register/index.js
@@ -87,14 +87,6 @@ async function register(server, options, done) {
 
       await server.pg.write.query(registerInsert({ nonce }))
 
-      await server.pg.write.query(
-        metricsInsert({
-          event: 'REGISTER',
-          os: '',
-          version: ''
-        })
-      )
-
       return { nonce }
     }
   })

--- a/lib/routes/register/register.test.js
+++ b/lib/routes/register/register.test.js
@@ -46,7 +46,7 @@ describe('register routes', () => {
 
     const payload = JSON.parse(response.payload)
 
-    expect(mockInsert).toHaveBeenCalledTimes(2)
+    expect(mockInsert).toHaveBeenCalledTimes(1)
     expect(response.statusCode).toEqual(200)
     expect(payload).toEqual(
       expect.objectContaining({


### PR DESCRIPTION
These writes can load the RDS instance being overloaded under large
loads. At the very least for initial release this will be removed.